### PR TITLE
fix: add upper bound validation for depth_km, bump to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "eq-insar"
-version = "0.1.0"
+version = "0.1.1"
 description = "Lightweight, physics-based forward model for generating synthetic InSAR deformation data from earthquake sources"
 readme = "README.md"
 license = {text = "MIT"}
@@ -44,6 +44,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+inversion = [
+    "scipy>=1.6.0",
+]
 viz = [
     "matplotlib>=3.3.0",
 ]
@@ -58,6 +61,7 @@ io = [
     "netCDF4>=1.5.0",
 ]
 all = [
+    "scipy>=1.6.0",
     "matplotlib>=3.3.0",
     "rasterio>=1.2.0",
     "netCDF4>=1.5.0",

--- a/src/eq_insar/generators/single.py
+++ b/src/eq_insar/generators/single.py
@@ -60,9 +60,11 @@ def _validate_source_parameters(
         raise ValueError(
             f"rake_deg={rake_deg} is outside the valid range [-180, 180]."
         )
-    if depth_km <= 0:
+    if not (0.0 < depth_km <= 700.0):
         raise ValueError(
-            f"depth_km={depth_km} must be positive (depth is measured downward)."
+            f"depth_km={depth_km} is outside the valid range (0, 700]. "
+            f"No earthquakes occur below ~700 km (mantle transition zone). "
+            f"For InSAR surface deformation, typical depths are 3–30 km."
         )
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -39,11 +39,11 @@ class TestSourceParameterValidation:
             generate_synthetic_insar(M0=-1e18, depth_km=10)
 
     def test_negative_depth(self):
-        with pytest.raises(ValueError, match="depth_km.*must be positive"):
+        with pytest.raises(ValueError, match="depth_km.*outside the valid range"):
             generate_synthetic_insar(Mw=6.0, depth_km=-5.0)
 
     def test_zero_depth(self):
-        with pytest.raises(ValueError, match="depth_km.*must be positive"):
+        with pytest.raises(ValueError, match="depth_km.*outside the valid range"):
             generate_synthetic_insar(Mw=6.0, depth_km=0.0)
 
     def test_dip_out_of_range(self):


### PR DESCRIPTION
- `depth_km` previously only checked `> 0`, allowing physically impossible values
    like 1005 km (no earthquakes occur below the mantle transition zone at ~700 km)                                                                                                                        
  - Added upper bound: valid range is now `(0, 700]` with a descriptive error message
  - Updated two test assertions to match the new error message wording                                                                                                                                     
  - Bumps version to `0.1.1` 